### PR TITLE
Fix Snowflake native transfer issue

### DIFF
--- a/src/universal_transfer_operator/data_providers/database/snowflake.py
+++ b/src/universal_transfer_operator/data_providers/database/snowflake.py
@@ -541,7 +541,7 @@ class SnowflakeDataProvider(DatabaseDataProvider):
         self._validate_before_copy_into(source_file, target_table, stage)
 
         # Below code is added due to breaking change in apache-airflow-providers-snowflake==3.2.0,
-        # we need to pass handler param to get the rows. But in version apache-airflow-providers-snowflake==3.1.0
+        # we need to pass handler param to get the rows. But in version apache-airflow-providers-snowflake<=3.1.0
         # if we pass the handler provider raises an exception AttributeError
         try:
             if packaging_version.parse(

--- a/src/universal_transfer_operator/data_providers/database/snowflake.py
+++ b/src/universal_transfer_operator/data_providers/database/snowflake.py
@@ -543,9 +543,8 @@ class SnowflakeDataProvider(DatabaseDataProvider):
         # if we pass the handler provider raises an exception AttributeError
         try:
             rows = self.hook.run(sql_statement)
-            rows = rows.fetchall()
-        except AttributeError:
-            pass
+            if rows is None:
+                rows = self.hook.run(sql_statement, handler=lambda cur: cur.fetchall())
         except ValueError as exe:
             raise DatabaseCustomError from exe
         finally:

--- a/src/universal_transfer_operator/data_providers/database/snowflake.py
+++ b/src/universal_transfer_operator/data_providers/database/snowflake.py
@@ -542,12 +542,10 @@ class SnowflakeDataProvider(DatabaseDataProvider):
         # we need to pass handler param to get the rows. But in version apache-airflow-providers-snowflake==3.1.0
         # if we pass the handler provider raises an exception AttributeError
         try:
-            rows = self.hook.run(sql_statement, handler=lambda cur: cur.fetchall())
+            rows = self.hook.run(sql_statement)
+            rows = rows.fetchall()
         except AttributeError:
-            try:
-                rows = self.hook.run(sql_statement)
-            except ValueError as exe:
-                raise DatabaseCustomError from exe
+            pass
         except ValueError as exe:
             raise DatabaseCustomError from exe
         finally:


### PR DESCRIPTION
When we execute copy into statement twice the first statement loads data in the table but fails if the `self.hook.run` doesn't accept the handler function as a result we execute the statement a second time but this time there is no file loaded. This PR solves the issue by ensuring the statement is executed only once to ensure the data is loading correctly. Also, this is an optimization to only execute the statement once. 

Issue - https://github.com/astronomer/apache-airflow-providers-transfers/actions/runs/5880997317/job/15949964951